### PR TITLE
hotfix for build compile image

### DIFF
--- a/ci/images/compile/centos-7-Dockerfile
+++ b/ci/images/compile/centos-7-Dockerfile
@@ -133,7 +133,7 @@ RUN wget https://github.com/microsoft/cpprestsdk/archive/refs/tags/v2.10.18.zip 
     && wget https://github.com/zaphoyd/websocketpp/archive/56123c87598f8b1dd471be83ca841ceae07f95ba.zip \
     && unzip 56123c87598f8b1dd471be83ca841ceae07f95ba.zip && rm -rf websocketpp && mv websocketpp-56123c87598f8b1dd471be83ca841ceae07f95ba websocketpp \
     && cd .. && mkdir build && cd build \
-    && cmake $CMAKE_OPT -DCMAKE_CXX_FLAGS=-Wno-error=unused-parameter -DBoost_USE_STATIC_LIBS=1 .. && make -j && make install \
+    && cmake $CMAKE_OPT -DCMAKE_CXX_FLAGS=-fPIC -Wno-error=unused-parameter -DBoost_USE_STATIC_LIBS=1 .. && make -j && make install \
     && rm -rf /cpprestsdk*  
 
 # googletest

--- a/ci/images/compile/centos-7-Dockerfile
+++ b/ci/images/compile/centos-7-Dockerfile
@@ -115,15 +115,15 @@ RUN python3 -m pip install pytest
 
 #install maven
 RUN cd opt \
-    && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz \
-    && tar xf apache-maven-3.8.6-bin.tar.gz \
+    && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz \
+    && tar xf apache-maven-3.8.7-bin.tar.gz \
     && rm apache-maven-*.tar.gz
 
 ARG CMAKE_OPT="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DBUILD_TESTS=0 -DBUILD_SAMPLES=0 -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
 
 # brpc
 RUN  wget https://github.com/apache/incubator-brpc/archive/refs/heads/release-1.2.zip \
-     && unzip release-1.2.zip && mv incubator-brpc-release-1.2 brpc && cd /brpc && mkdir build && cd build \
+     && unzip release-1.2.zip && mv brpc-release-1.2 brpc && cd /brpc && mkdir build && cd build \
      && cmake $CMAKE_OPT -DBUILD_UNIT_TESTS=0 .. && make -j && make install \
      && rm -rf /brpc*
 
@@ -177,5 +177,5 @@ RUN sed -i '3 s/-lgomp/-l:libgomp.a/' /usr/local/lib64/libgomp.spec
 ENV JAVA_HOME=/usr/local/lib64:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server \
     LD_LIBRARY_PATH=/usr/local/lib64:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server:$LD_LIBRARY_PATH \
     PYTHONPATH=/usr/local/lib64:$PYTHONPATH \
-    PATH=/opt/apache-maven-3.8.6/bin:$PATH
+    PATH=/opt/apache-maven-3.8.7/bin:$PATH
 

--- a/ci/images/compile/centos-7-Dockerfile
+++ b/ci/images/compile/centos-7-Dockerfile
@@ -75,7 +75,7 @@ RUN wget https://github.com/gflags/gflags/archive/v2.2.1.tar.gz -O gflags-2.2.1.
 # install leveldb
 RUN wget https://github.com/google/leveldb/archive/refs/tags/v1.20.zip \
     && unzip v1.20.zip && mv leveldb-1.20 leveldb \
-    && cd leveldb && git checkout v1.20 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" make -j4 \
+    && cd leveldb && CFLAGS="-fPIC" CXXFLAGS="-fPIC" make -j4 \
     && cp -r ./include/leveldb/ /usr/local/include/ \
     && cp ./out-shared/libleveldb.so.1.20 /usr/local/lib/ \
     && cp ./out-static/libleveldb.a /usr/local/lib/ \

--- a/ci/images/compile/centos-8-Dockerfile
+++ b/ci/images/compile/centos-8-Dockerfile
@@ -126,7 +126,7 @@ RUN wget https://github.com/microsoft/cpprestsdk/archive/refs/tags/v2.10.18.zip 
     && wget https://github.com/zaphoyd/websocketpp/archive/56123c87598f8b1dd471be83ca841ceae07f95ba.zip \
     && unzip 56123c87598f8b1dd471be83ca841ceae07f95ba.zip && rm -rf websocketpp && mv websocketpp-56123c87598f8b1dd471be83ca841ceae07f95ba websocketpp \
     && cd .. && mkdir build && cd build \
-    && cmake $CMAKE_OPT -DCMAKE_CXX_FLAGS=-Wno-error=unused-parameter -DBoost_USE_STATIC_LIBS=1 .. && make -j && make install \
+    && cmake $CMAKE_OPT -DCMAKE_CXX_FLAGS=-fPIC -Wno-error=unused-parameter -DBoost_USE_STATIC_LIBS=1 .. && make -j && make install \
     && rm -rf /cpprestsdk*  
 
 # googletest

--- a/ci/images/compile/centos-8-Dockerfile
+++ b/ci/images/compile/centos-8-Dockerfile
@@ -77,7 +77,7 @@ RUN wget https://github.com/gflags/gflags/archive/v2.2.1.tar.gz -O gflags-2.2.1.
 # install leveldb
 RUN wget https://github.com/google/leveldb/archive/refs/tags/v1.20.zip \
     && unzip v1.20.zip && mv leveldb-1.20 leveldb \
-    && cd leveldb && git checkout v1.20 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" make -j4 \
+    && cd leveldb && CFLAGS="-fPIC" CXXFLAGS="-fPIC" make -j4 \
     && cp -r ./include/leveldb/ /usr/local/include/ \
     && cp ./out-shared/libleveldb.so.1.20 /usr/local/lib/ \
     && cp ./out-static/libleveldb.a /usr/local/lib/ \

--- a/ci/images/compile/centos-8-Dockerfile
+++ b/ci/images/compile/centos-8-Dockerfile
@@ -108,15 +108,15 @@ RUN python3 -m pip install pytest
 
 # install maven
 RUN cd opt \
-    && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz \
-    && tar xf apache-maven-3.8.6-bin.tar.gz \
+    && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz \
+    && tar xf apache-maven-3.8.7-bin.tar.gz \
     && rm apache-maven-*.tar.gz
 
 ARG CMAKE_OPT="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DBUILD_TESTS=0 -DBUILD_SAMPLES=0 -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
 
 # brpc
 RUN  wget https://github.com/apache/incubator-brpc/archive/refs/heads/release-1.2.zip \
-     && unzip release-1.2.zip && mv incubator-brpc-release-1.2 brpc && cd /brpc && mkdir build && cd build \
+     && unzip release-1.2.zip && mv brpc-release-1.2 brpc && cd /brpc && mkdir build && cd build \
      && cmake $CMAKE_OPT -DBUILD_UNIT_TESTS=0 .. && make -j && make install \
      && rm -rf /brpc*
 
@@ -179,4 +179,4 @@ RUN sed -i '3 s/-lgomp/-l:libgomp.a/' /usr/local/lib64/libgomp.spec
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0/jre/ \
     LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server:$LD_LIBRARY_PATH \
     PYTHONPATH=/usr/local/lib64:$PYTHONPATH \
-    PATH=/opt/apache-maven-3.8.6/bin:$PATH
+    PATH=/opt/apache-maven-3.8.7/bin:$PATH

--- a/ci/images/compile/ubuntu-18.04-Dockerfile
+++ b/ci/images/compile/ubuntu-18.04-Dockerfile
@@ -120,15 +120,15 @@ RUN python3 -m pip install pytest
 
 #install maven
 RUN cd opt \
-    && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz \
-    && tar xf apache-maven-3.8.6-bin.tar.gz \
+    && wget --no-check-certificate https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz \
+    && tar xf apache-maven-3.8.7-bin.tar.gz \
     && rm apache-maven-*.tar.gz
 
 ARG CMAKE_OPT="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=0 -DBUILD_TESTS=0 -DBUILD_SAMPLES=0 -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
 
 # brpc
 RUN  wget https://github.com/apache/incubator-brpc/archive/refs/heads/release-1.2.zip \
-     && unzip release-1.2.zip && mv incubator-brpc-release-1.2 brpc && cd /brpc && mkdir build && cd build \
+     && unzip release-1.2.zip && mv brpc-release-1.2 brpc && cd /brpc && mkdir build && cd build \
      && cmake $CMAKE_OPT -DBUILD_UNIT_TESTS=0 .. && make -j && make install \
      && rm -rf /brpc*
 

--- a/ci/images/compile/ubuntu-18.04-Dockerfile
+++ b/ci/images/compile/ubuntu-18.04-Dockerfile
@@ -82,7 +82,7 @@ RUN wget https://github.com/gflags/gflags/archive/v2.2.1.tar.gz -O gflags-2.2.1.
 # install leveldb
 RUN wget https://github.com/google/leveldb/archive/refs/tags/v1.20.zip \
     && unzip v1.20.zip && mv leveldb-1.20 leveldb \
-    && cd leveldb && git checkout v1.20 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" make -j4 \
+    && cd leveldb && CFLAGS="-fPIC" CXXFLAGS="-fPIC" make -j4 \
     && cp -r ./include/leveldb/ /usr/local/include/ \
     && cp ./out-shared/libleveldb.so.1.20 /usr/local/lib/ \
     && cp ./out-static/libleveldb.a /usr/local/lib/ \

--- a/ci/images/compile/ubuntu-18.04-Dockerfile
+++ b/ci/images/compile/ubuntu-18.04-Dockerfile
@@ -138,7 +138,7 @@ RUN wget https://github.com/microsoft/cpprestsdk/archive/refs/tags/v2.10.18.zip 
     && wget https://github.com/zaphoyd/websocketpp/archive/56123c87598f8b1dd471be83ca841ceae07f95ba.zip \
     && unzip 56123c87598f8b1dd471be83ca841ceae07f95ba.zip && rm -rf websocketpp && mv websocketpp-56123c87598f8b1dd471be83ca841ceae07f95ba websocketpp \
     && cd .. && mkdir build && cd build \
-    && cmake $CMAKE_OPT -DCMAKE_CXX_FLAGS=-Wno-error=unused-parameter -DBoost_USE_STATIC_LIBS=1 .. && make -j && make install \
+    && cmake $CMAKE_OPT -DCMAKE_CXX_FLAGS=-fPIC -Wno-error=unused-parameter -DBoost_USE_STATIC_LIBS=1 .. && make -j && make install \
     && rm -rf /cpprestsdk*  
 
 # googletest


### PR DESCRIPTION
1. 直接下载的leveldb的源码解包。所以不包含git信息。运行git checkout失败
2. 其他的依赖项编译的时候都加上了 `-fPIC`选项，所以给`cpprest`也加了